### PR TITLE
refactor: use base and final classes for TlvElements

### DIFF
--- a/lib/src/tlv_elements/certificate/key_locator.dart
+++ b/lib/src/tlv_elements/certificate/key_locator.dart
@@ -9,7 +9,7 @@ import "../name/name.dart";
 import "../tlv_element.dart";
 import "../tlv_type.dart";
 
-abstract class KeyLocator extends KnownTlvElement {
+abstract base class KeyLocator extends KnownTlvElement {
   const KeyLocator();
 
   factory KeyLocator.fromValue(List<int> value) {

--- a/lib/src/tlv_elements/name/name.dart
+++ b/lib/src/tlv_elements/name/name.dart
@@ -20,7 +20,7 @@ import "name_component.dart";
 /// NDN Packet Specification with regard to the [canonical order] of NDN names.
 ///
 /// [canonical order]: https://docs.named-data.net/NDN-packet-spec/current/name.html#canonical-order
-class Name extends KnownTlvElement implements Comparable<Name> {
+final class Name extends KnownTlvElement implements Comparable<Name> {
   const Name(this.nameComponents);
 
   factory Name.fromValue(List<int> value) {

--- a/lib/src/tlv_elements/nfd_management/control_parameters.dart
+++ b/lib/src/tlv_elements/nfd_management/control_parameters.dart
@@ -9,7 +9,7 @@ import "../name/name.dart";
 import "../tlv_element.dart";
 import "../tlv_type.dart";
 
-class ControlParameters extends KnownTlvElement {
+final class ControlParameters extends KnownTlvElement {
   const ControlParameters({
     this.name,
   });

--- a/lib/src/tlv_elements/nfd_management/control_response.dart
+++ b/lib/src/tlv_elements/nfd_management/control_response.dart
@@ -10,7 +10,7 @@ import "../tlv_element.dart";
 import "../tlv_type.dart";
 import "status.dart";
 
-class ControlResponse extends KnownTlvElement {
+final class ControlResponse extends KnownTlvElement {
   const ControlResponse(
     this.statusCode,
     this.statusText, [

--- a/lib/src/tlv_elements/nfd_management/status.dart
+++ b/lib/src/tlv_elements/nfd_management/status.dart
@@ -10,7 +10,7 @@ import "../../extensions/non_negative_integer.dart";
 import "../tlv_element.dart";
 import "../tlv_type.dart";
 
-class StatusCode extends KnownTlvElement {
+final class StatusCode extends KnownTlvElement {
   const StatusCode(this.code);
 
   factory StatusCode.fromValue(List<int> value) {
@@ -31,7 +31,7 @@ class StatusCode extends KnownTlvElement {
   String toString() => "StatusCode (type: $type): $code";
 }
 
-class StatusText extends KnownTlvElement {
+final class StatusText extends KnownTlvElement {
   const StatusText(this.text);
 
   factory StatusText.fromValue(List<int> value) {

--- a/lib/src/tlv_elements/nonce.dart
+++ b/lib/src/tlv_elements/nonce.dart
@@ -16,7 +16,7 @@ extension ByteExtension on int {
   bool get isByte => this >= 0 && this <= 255;
 }
 
-class Nonce extends KnownTlvElement {
+final class Nonce extends KnownTlvElement {
   Nonce([List<int>? value])
       : value = value ?? List.generate(4, (index) => Random().nextInt(256));
 
@@ -34,7 +34,7 @@ class Nonce extends KnownTlvElement {
   final List<int> value;
 }
 
-class CanBePrefix extends KnownTlvElement {
+final class CanBePrefix extends KnownTlvElement {
   @override
   TlvType get tlvType => TlvType.canBePrefix;
 
@@ -42,7 +42,7 @@ class CanBePrefix extends KnownTlvElement {
   List<int> get value => const [];
 }
 
-class MustBeFresh extends KnownTlvElement {
+final class MustBeFresh extends KnownTlvElement {
   @override
   TlvType get tlvType => TlvType.mustBeFresh;
 
@@ -50,7 +50,7 @@ class MustBeFresh extends KnownTlvElement {
   List<int> get value => const [];
 }
 
-class ForwardingHint extends KnownTlvElement {
+final class ForwardingHint extends KnownTlvElement {
   const ForwardingHint(this.names);
 
   @override
@@ -62,7 +62,7 @@ class ForwardingHint extends KnownTlvElement {
   List<int> get value => names.encode().toList();
 }
 
-class InterestLifetime extends KnownTlvElement {
+final class InterestLifetime extends KnownTlvElement {
   const InterestLifetime(this.duration);
 
   @override
@@ -74,7 +74,7 @@ class InterestLifetime extends KnownTlvElement {
   List<int> get value => NonNegativeInteger(duration.inMilliseconds).encode();
 }
 
-class HopLimit extends KnownTlvElement {
+final class HopLimit extends KnownTlvElement {
   const HopLimit(this.hopLimit);
 
   @override

--- a/lib/src/tlv_elements/packet/data_packet/content.dart
+++ b/lib/src/tlv_elements/packet/data_packet/content.dart
@@ -7,7 +7,7 @@
 import "../../tlv_element.dart";
 import "../../tlv_type.dart";
 
-class Content extends KnownTlvElement {
+final class Content extends KnownTlvElement {
   const Content(this.value);
 
   @override

--- a/lib/src/tlv_elements/packet/data_packet/data_signature.dart
+++ b/lib/src/tlv_elements/packet/data_packet/data_signature.dart
@@ -76,7 +76,7 @@ class DataSignature {
   }
 }
 
-class SignatureInfo extends KnownTlvElement {
+final class SignatureInfo extends KnownTlvElement {
   // TODO: Add KeyLocator
   const SignatureInfo(this.signatureType);
 
@@ -93,7 +93,7 @@ class SignatureInfo extends KnownTlvElement {
 }
 
 // TODO: This only implements DigestSha256 for now
-class SignatureValue extends KnownTlvElement {
+final class SignatureValue extends KnownTlvElement {
   SignatureValue(List<int> content, SignatureType signatureType)
       : value = _createSignature(content, signatureType);
 

--- a/lib/src/tlv_elements/tlv_element.dart
+++ b/lib/src/tlv_elements/tlv_element.dart
@@ -22,7 +22,7 @@ import "packet/nack_packet.dart";
 import "tlv_type.dart";
 
 @immutable
-abstract class TlvElement {
+abstract base class TlvElement {
   const TlvElement();
 
   int get type;
@@ -204,7 +204,7 @@ abstract class TlvElement {
   }
 }
 
-abstract class KnownTlvElement extends TlvElement {
+abstract base class KnownTlvElement extends TlvElement {
   const KnownTlvElement();
 
   TlvType get tlvType;


### PR DESCRIPTION
This PR introduces the keywords `base` and `final` for TlvElement classes where possible, making the implementation a bit more robust and type-safe.